### PR TITLE
Add directory path by using directory browser

### DIFF
--- a/layout_tools.py
+++ b/layout_tools.py
@@ -668,10 +668,10 @@ class SCENE_OT_ImportAssets(Operator, ImportHelper):
         new_scene = bpy.data.scenes[scene_name]
 
         if self.is_import_scs:
-            for attr in ["frame_step", "layers", "sync_mode",
-                         "use_audio", "use_audio_scrub",
-                         "use_audio_sync", "use_frame_drop",
-                         "use_nodes"]:
+            for attr in ["frame_step", "layers", "sync_mode", "use_audio", "use_audio_scrub",
+                         "use_audio_sync", "use_frame_drop", "use_nodes"]:
+                if not getattr(cur_scene, attr, None):
+                    continue
                 setattr(cur_scene, attr, getattr(new_scene, attr))
 
         if self.is_import_res:
@@ -708,7 +708,7 @@ class SCENE_OT_ImportAssets(Operator, ImportHelper):
                          'diffuse_bounces', 'diffuse_samples', 'feature_set',
                          'film_exposure', 'film_transparent', 'filter_type', 'filter_width',
                          'glossy_bounces', 'glossy_samples', 'max_bounces',
-                         'mesh_light_samples', 'min_bounces', 'name', 'preview_aa_samples',
+                         'mesh_light_samples', 'min_bounces', 'preview_aa_samples',
                          'preview_active_layer', 'preview_pause', 'preview_samples',
                          'preview_start_resolution', 'progressive',
                          'sample_all_lights_direct', 'sample_all_lights_indirect',
@@ -733,6 +733,9 @@ class SCENE_OT_ImportAssets(Operator, ImportHelper):
                         getattr(new_scene.render.image_settings, attr))
 
         for obj in new_scene.objects:
+            if not self.is_import_cam and getattr(obj, "type", None) == "CAMERA":
+                continue
+
             obj.select = False
             cur_scene.objects.link(obj)
         cur_scene.update()


### PR DESCRIPTION
With this you can add the path with directory browser, but seems there's an issue. I have to remove the first `//` on the layout path for make the addon works, otherwise you'll get the following error

```
Traceback (most recent call last):
  File "/home/aditia/.config/blender/2.72/scripts/addons/layout_tools.py", line 511, in invoke
    os.makedirs(layoutdir)
  File "/home/aditia/blender-git/build_linux/bin/2.72/python/lib/python3.4/os.py", line 227, in makedirs
    makedirs(head, mode, exist_ok)
  File "/home/aditia/blender-git/build_linux/bin/2.72/python/lib/python3.4/os.py", line 237, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '//layout_files'
```
